### PR TITLE
Fix array keys to match server_push regex keys

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -54,8 +54,8 @@ class Config extends AbstractHelper
     public function getServerPushLimits(): array {
         return [
             'image' => (int) $this->scopeConfig->getValue(self::PERFORMANCE_SERVER_PUSH_MAX_IMAGES_CONFIG_PATH, ScopeInterface::SCOPE_STORE),
-            'css' => (int) $this->scopeConfig->getValue(self::PERFORMANCE_SERVER_PUSH_MAX_CSS_CONFIG_PATH, ScopeInterface::SCOPE_STORE),
-            'js' => (int) $this->scopeConfig->getValue(self::PERFORMANCE_SERVER_PUSH_MAX_JS_CONFIG_PATH, ScopeInterface::SCOPE_STORE),
+            'style' => (int) $this->scopeConfig->getValue(self::PERFORMANCE_SERVER_PUSH_MAX_CSS_CONFIG_PATH, ScopeInterface::SCOPE_STORE),
+            'script' => (int) $this->scopeConfig->getValue(self::PERFORMANCE_SERVER_PUSH_MAX_JS_CONFIG_PATH, ScopeInterface::SCOPE_STORE),
             'font' => (int) $this->scopeConfig->getValue(self::PERFORMANCE_SERVER_PUSH_MAX_FONT_CONFIG_PATH, ScopeInterface::SCOPE_STORE)
         ];
     }


### PR DESCRIPTION
A forma anterior criava as chaves "js" e "css" no array de retorno do método getServerPushLimits(), do helper de configuração, porém, no plugin do HttpResponse, após obter os valores, há na linha 146 uma tentativa de buscar nesta matriz os tipos definidos na constante MATCH_REGEX['server_push'], que por sua vez estão definidos como "script" e "style", causando erro de chave não encontrada no array.

```
1 exception(s):
Exception #0 (Exception): Warning: Undefined array key "script" in /app/vendor/the_it_nerd/module-performance/Plugin/HttpResponsePlugin.php on line 146

Exception #0 (Exception): Warning: Undefined array key "script" in /app/vendor/the_it_nerd/module-performance/Plugin/HttpResponsePlugin.php on line 146
<pre>#1 TheITNerd\Performance\Plugin\HttpResponsePlugin->addServerPushHeader() called at [vendor/the_it_nerd/module-performance/Plugin/HttpResponsePlugin.php:61]
#2 TheITNerd\Performance\Plugin\HttpResponsePlugin->beforeSendResponse() called at [vendor/magento/framework/Interception/Interceptor.php:121]
#3 Magento\Framework\App\Response\Http\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#4 Magento\Framework\App\Response\Http\Interceptor->___callPlugins() called at [generated/code/Magento/Framework/App/Response/Http/Interceptor.php:23]
#5 Magento\Framework\App\Response\Http\Interceptor->sendResponse() called at [vendor/magento/framework/App/Bootstrap.php:265]
#6 Magento\Framework\App\Bootstrap->run() called at [pub/index.php:30]
</pre>
```